### PR TITLE
Fix openURL was deprecated in iOS 10

### DIFF
--- a/Sources/OpenInSafariActivity.swift
+++ b/Sources/OpenInSafariActivity.swift
@@ -39,8 +39,14 @@ class OpenInSafariActivity: UIActivity {
 
     override func perform() {
         if let url = self.url {
-            let completed = UIApplication.shared.openURL(url)
-            self.activityDidFinish(completed)
+            if #available(iOS 10.0, *) {
+                UIApplication.shared.open(url, options: [:]) { completed in
+                    self.activityDidFinish(completed)
+                }
+            } else {
+                let completed = UIApplication.shared.openURL(url)
+                self.activityDidFinish(completed)
+            }
         } else {
             self.activityDidFinish(false)
         }


### PR DESCRIPTION
<img width="527" alt="screen shot 2016-10-25 at 11 27 12" src="https://cloud.githubusercontent.com/assets/1088217/19680589/99c15ca6-9aa6-11e6-8311-01a9fe31cb73.png">
