### PR TITLE
Remove separator from tableviews

### DIFF
--- a/Sources/SweetTableController.swift
+++ b/Sources/SweetTableController.swift
@@ -7,6 +7,7 @@ open class SweetTableController: UIViewController {
     public init(style: UITableViewStyle = .plain) {
         let view = UITableView(frame: .zero, style: style)
         view.translatesAutoresizingMaskIntoConstraints = false
+        view.separatorStyle = .none
         self.tableView = view
 
         super.init(nibName: nil, bundle: nil)


### PR DESCRIPTION
- Table view should not be responsible for cell design.