### PR TITLE
Improve and unit test previous and next indexPath helpers

### DIFF
--- a/Demo.xcodeproj/xcshareddata/xcschemes/iOSTests.xcscheme
+++ b/Demo.xcodeproj/xcshareddata/xcschemes/iOSTests.xcscheme
@@ -26,7 +26,8 @@
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
-      shouldUseLaunchSchemeArgsEnv = "YES">
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">

--- a/Sources/IndexPath+Sweet.swift
+++ b/Sources/IndexPath+Sweet.swift
@@ -29,36 +29,6 @@
             }
         }
 
-        public func next(collectionView: UICollectionView) -> IndexPath? {
-            var found = false
-            let indexPaths = collectionView.indexPaths
-            for indexPath in indexPaths {
-                if found == true {
-                    return indexPath
-                }
-
-                if indexPath == self {
-                    found = true
-                }
-            }
-
-            return nil
-        }
-
-        public func previous(collectionView: UICollectionView) -> IndexPath? {
-            var previousIndexPath: IndexPath?
-            let indexPaths = collectionView.indexPaths
-            for indexPath in indexPaths {
-                if indexPath == self {
-                    return previousIndexPath
-                }
-
-                previousIndexPath = indexPath
-            }
-
-            return nil
-        }
-
         public static func firstIndexPathForIndex(collectionView: UICollectionView, index: Int) -> IndexPath? {
             var count = 0
             let sections = collectionView.numberOfSections

--- a/Sources/UICollectionView+Sweet.swift
+++ b/Sources/UICollectionView+Sweet.swift
@@ -36,5 +36,35 @@
 
             return indexPaths
         }
+
+        public func nextIndexPath(to indexPath: IndexPath) -> IndexPath? {
+            var found = false
+            let indexPaths = self.indexPaths
+            for currentIndexPath in indexPaths {
+                if found == true {
+                    return currentIndexPath
+                }
+
+                if currentIndexPath == indexPath {
+                    found = true
+                }
+            }
+
+            return nil
+        }
+
+        public func previousIndexPath(to indexPath: IndexPath) -> IndexPath? {
+            var previousIndexPath: IndexPath?
+            let indexPaths = self.indexPaths
+            for currentIndexPath in indexPaths {
+                if currentIndexPath == indexPath {
+                    return previousIndexPath
+                }
+
+                previousIndexPath = currentIndexPath
+            }
+            
+            return nil
+        }
     }
 #endif

--- a/Sources/UICollectionView+Sweet.swift
+++ b/Sources/UICollectionView+Sweet.swift
@@ -37,31 +37,31 @@
             return indexPaths
         }
 
-        public func nextIndexPath(to indexPath: IndexPath) -> IndexPath? {
+        public func nextIndexPath(to indexPath: IndexPath, offset: Int = 0) -> IndexPath? {
+            return UICollectionView.nextIndexPath(to: indexPath, offset: offset, source: self.indexPaths)
+        }
+
+        public func previousIndexPath(to indexPath: IndexPath, offset: Int = 0) -> IndexPath? {
+            return UICollectionView.nextIndexPath(to: indexPath, offset: offset, source: self.indexPaths.reversed())
+        }
+
+        private class func nextIndexPath(to indexPath: IndexPath, offset: Int = 0, source: [IndexPath]) -> IndexPath? {
             var found = false
-            let indexPaths = self.indexPaths
+            let indexPaths = source
+            var skippedResults = offset
+
             for currentIndexPath in indexPaths {
                 if found == true {
-                    return currentIndexPath
+                    if skippedResults <= 0 {
+                        return currentIndexPath
+                    }
+
+                    skippedResults -= 1
                 }
 
                 if currentIndexPath == indexPath {
                     found = true
                 }
-            }
-
-            return nil
-        }
-
-        public func previousIndexPath(to indexPath: IndexPath) -> IndexPath? {
-            var previousIndexPath: IndexPath?
-            let indexPaths = self.indexPaths
-            for currentIndexPath in indexPaths {
-                if currentIndexPath == indexPath {
-                    return previousIndexPath
-                }
-
-                previousIndexPath = currentIndexPath
             }
             
             return nil

--- a/Tests/IndexPathTests.swift
+++ b/Tests/IndexPathTests.swift
@@ -29,21 +29,4 @@ class IndexPathTests: XCTestCase {
         XCTAssert(fourthPath.comparePosition(to: thirdPath) == .ahead)
         XCTAssert(fourthPath.comparePosition(to: fourthPath) == .same)
     }
-
-    func testIndexPaths() {
-        class DataSource: NSObject, UICollectionViewDataSource {
-            func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-                return 1
-            }
-
-            func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
-                return UICollectionViewCell()
-            }
-        }
-
-        let collectionView = UICollectionView(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
-        let dataSource = DataSource()
-        collectionView.dataSource = dataSource
-        XCTAssertEqual(collectionView.indexPaths, [IndexPath(item: 0, section: 0)])
-    }
 }

--- a/Tests/UICollectionViewTests.swift
+++ b/Tests/UICollectionViewTests.swift
@@ -1,5 +1,99 @@
 import UIKit
 import XCTest
 
+class DataSource: NSObject, UICollectionViewDataSource {
+    let numberOfSections: Int
+    let numberOfRowsInEachSection: Int
+
+    init(numberOfSections: Int, numberOfRowsInEachSection: Int) {
+        self.numberOfSections = numberOfSections
+        self.numberOfRowsInEachSection = numberOfRowsInEachSection
+    }
+
+    func numberOfSections(in collectionView: UICollectionView) -> Int {
+        return self.numberOfSections
+    }
+
+    func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
+        return self.numberOfRowsInEachSection
+    }
+
+    func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
+        return UICollectionViewCell()
+    }
+}
+
+extension UICollectionView {
+    convenience init(dataSource: DataSource) {
+        self.init(frame: .zero, collectionViewLayout: UICollectionViewFlowLayout())
+        self.dataSource = dataSource
+    }
+}
+
 class UICollectionViewTests: XCTestCase {
+    func testIndexPaths() {
+        let dataSource = DataSource(numberOfSections: 1, numberOfRowsInEachSection: 1)
+        let collectionView = UICollectionView(dataSource: dataSource)
+        XCTAssertEqual(collectionView.indexPaths, [IndexPath(item: 0, section: 0)])
+    }
+
+    func testNextForEmptyCollectionView() {
+        let dataSource = DataSource(numberOfSections: 0, numberOfRowsInEachSection: 0)
+        let collectionView = UICollectionView(dataSource: dataSource)
+        let nextIndexPath = collectionView.nextIndexPath(to: IndexPath(item: 0, section: 0))
+        XCTAssertNil(nextIndexPath)
+    }
+
+    func testNextForCollectionViewWithJustOneRow() {
+        let dataSource = DataSource(numberOfSections: 1, numberOfRowsInEachSection: 1)
+        let collectionView = UICollectionView(dataSource: dataSource)
+        let nextIndexPath = collectionView.nextIndexPath(to: IndexPath(item: 0, section: 0))
+        XCTAssertNil(nextIndexPath)
+    }
+
+    func testNextForIndexPathInTheSameSection() {
+        let dataSource = DataSource(numberOfSections: 1, numberOfRowsInEachSection: 2)
+        let collectionView = UICollectionView(dataSource: dataSource)
+        let nextIndexPath = collectionView.nextIndexPath(to: IndexPath(item: 0, section: 0))
+        let expected = IndexPath(item: 1, section: 0)
+        XCTAssertEqual(nextIndexPath, expected)
+    }
+
+    func testNextForIndexPathInDifferentSections() {
+        let dataSource = DataSource(numberOfSections: 2, numberOfRowsInEachSection: 1)
+        let collectionView = UICollectionView(dataSource: dataSource)
+        let nextIndexPath = collectionView.nextIndexPath(to: IndexPath(item: 0, section: 0))
+        let expected = IndexPath(item: 0, section: 1)
+        XCTAssertEqual(nextIndexPath, expected)
+    }
+
+    func testPreviousForEmptyCollectionView() {
+        let dataSource = DataSource(numberOfSections: 0, numberOfRowsInEachSection: 0)
+        let collectionView = UICollectionView(dataSource: dataSource)
+        let previousIndexPath = collectionView.previousIndexPath(to: IndexPath(item: 0, section: 0))
+        XCTAssertNil(previousIndexPath)
+    }
+
+    func testPreviousForCollectionViewWithJustOneRow() {
+        let dataSource = DataSource(numberOfSections: 1, numberOfRowsInEachSection: 1)
+        let collectionView = UICollectionView(dataSource: dataSource)
+        let previousIndexPath = collectionView.previousIndexPath(to: IndexPath(item: 0, section: 0))
+        XCTAssertNil(previousIndexPath)
+    }
+
+    func testPreviousForIndexPathInTheSameSection() {
+        let dataSource = DataSource(numberOfSections: 1, numberOfRowsInEachSection: 2)
+        let collectionView = UICollectionView(dataSource: dataSource)
+        let previousIndexPath = collectionView.previousIndexPath(to: IndexPath(item: 1, section: 0))
+        let expected = IndexPath(item: 0, section: 0)
+        XCTAssertEqual(previousIndexPath, expected)
+    }
+
+    func testPreviousForIndexPathInDifferentSections() {
+        let dataSource = DataSource(numberOfSections: 2, numberOfRowsInEachSection: 1)
+        let collectionView = UICollectionView(dataSource: dataSource)
+        let previousIndexPath = collectionView.previousIndexPath(to: IndexPath(item: 0, section: 1))
+        let expected = IndexPath(item: 0, section: 0)
+        XCTAssertEqual(previousIndexPath, expected)
+    }
 }

--- a/Tests/UICollectionViewTests.swift
+++ b/Tests/UICollectionViewTests.swift
@@ -67,6 +67,22 @@ class UICollectionViewTests: XCTestCase {
         XCTAssertEqual(nextIndexPath, expected)
     }
 
+    func testNextForIndexPathWithOffsetInSameSection() {
+        let dataSource = DataSource(numberOfSections: 1, numberOfRowsInEachSection: 3)
+        let collectionView = UICollectionView(dataSource: dataSource)
+        let nextIndexPath = collectionView.nextIndexPath(to: IndexPath(item: 0, section: 0), offset: 1)
+        let expected = IndexPath(item: 2, section: 0)
+        XCTAssertEqual(nextIndexPath, expected)
+    }
+
+    func testNextForIndexPathWithOffsetInDifferentSection() {
+        let dataSource = DataSource(numberOfSections: 2, numberOfRowsInEachSection: 2)
+        let collectionView = UICollectionView(dataSource: dataSource)
+        let nextIndexPath = collectionView.nextIndexPath(to: IndexPath(item: 0, section: 0), offset: 1)
+        let expected = IndexPath(item: 0, section: 1)
+        XCTAssertEqual(nextIndexPath, expected)
+    }
+
     func testPreviousForEmptyCollectionView() {
         let dataSource = DataSource(numberOfSections: 0, numberOfRowsInEachSection: 0)
         let collectionView = UICollectionView(dataSource: dataSource)
@@ -93,6 +109,22 @@ class UICollectionViewTests: XCTestCase {
         let dataSource = DataSource(numberOfSections: 2, numberOfRowsInEachSection: 1)
         let collectionView = UICollectionView(dataSource: dataSource)
         let previousIndexPath = collectionView.previousIndexPath(to: IndexPath(item: 0, section: 1))
+        let expected = IndexPath(item: 0, section: 0)
+        XCTAssertEqual(previousIndexPath, expected)
+    }
+
+    func testPreviousForIndexPathWithOffsetInSameSection() {
+        let dataSource = DataSource(numberOfSections: 1, numberOfRowsInEachSection: 3)
+        let collectionView = UICollectionView(dataSource: dataSource)
+        let previousIndexPath = collectionView.previousIndexPath(to: IndexPath(item: 2, section: 0), offset: 1)
+        let expected = IndexPath(item: 0, section: 0)
+        XCTAssertEqual(previousIndexPath, expected)
+    }
+
+    func testPreviousForIndexPathWithOffsetInDifferentSection() {
+        let dataSource = DataSource(numberOfSections: 2, numberOfRowsInEachSection: 2)
+        let collectionView = UICollectionView(dataSource: dataSource)
+        let previousIndexPath = collectionView.previousIndexPath(to: IndexPath(item: 0, section: 1), offset: 1)
         let expected = IndexPath(item: 0, section: 0)
         XCTAssertEqual(previousIndexPath, expected)
     }


### PR DESCRIPTION
Would be nice to get feedback on the method signature.

The goal of these methods is to give you the previous or next index path inside a collection view.
```swift
collectionView.nextIndexPath(to: IndexPath(item: 0, section: 0))
collectionView.previousIndexPath(to: IndexPath(item: 0, section: 2))
```

I also added the `offset` attribute to skip certain results. I need this because in my app I have a paginated scrollview, and while I scroll as soon as I find an image that requires metadata I want to start loading metadata for either the 10 next or 10 previous elements, depends on the direction of the scrolling.