### PR TITLE
Fix search bar container issues

### DIFF
--- a/Sources/SearchableCollectionController.swift
+++ b/Sources/SearchableCollectionController.swift
@@ -60,7 +60,6 @@ open class SearchableCollectionController: SweetCollectionController {
         self.title = "Searchable"
 
         if #available(iOS 11.0, *) {
-            self.searchBar.set(height: self.searchBar.frame.height)
             self.navigationController?.navigationBar.prefersLargeTitles = prefersLargeTitles
             self.navigationItem.searchController = searchController
             self.navigationItem.hidesSearchBarWhenScrolling = hidesSearchBarWhenScrolling

--- a/Sources/SearchableCollectionController.swift
+++ b/Sources/SearchableCollectionController.swift
@@ -27,8 +27,12 @@ open class SearchableCollectionController: SweetCollectionController {
             controller.dimsBackgroundDuringPresentation = false
         #endif
 
-        controller.searchBar.autoresizingMask = [.flexibleWidth]
         controller.delegate = self
+
+        guard #available(iOS 11.0, *) else {
+            controller.searchBar.autoresizingMask = [.flexibleWidth]
+            return controller
+        }
 
         return controller
     }()

--- a/Sources/SearchableCollectionController.swift
+++ b/Sources/SearchableCollectionController.swift
@@ -22,7 +22,7 @@ open class SearchableCollectionController: SweetCollectionController {
     /// The installed UISearchController. Override the delegate methods (call super) if necessary.
     open lazy var searchController: UISearchController = {
         let controller = UISearchController(searchResultsController: nil)
-        controller.hidesNavigationBarDuringPresentation = false
+
         #if os(iOS)
             controller.dimsBackgroundDuringPresentation = false
         #endif
@@ -30,7 +30,9 @@ open class SearchableCollectionController: SweetCollectionController {
         controller.delegate = self
 
         if #available(iOS 11.0, *) {
+            controller.hidesNavigationBarDuringPresentation = false
         } else {
+            controller.hidesNavigationBarDuringPresentation = true
             controller.searchBar.autoresizingMask = [.flexibleWidth]
         }
 


### PR DESCRIPTION
That does not preserve initial purpose of component and search bar properties, as on iOS 11 it is part of navigation bar and behaves differently. Thus I made it just work on iOS 11, as previous implementation is broken on os version in question.